### PR TITLE
fix: add YAML frontmatter to /cycle, /hunt, /knock skills

### DIFF
--- a/.claude/skills/cycle/SKILL.md
+++ b/.claude/skills/cycle/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: cycle
+description: Post-session documentation chain — propagate changes through lab-notebook, journal, architecture, MEMORY, snapshot, and commit.
+user-invocable: true
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+---
+
 # Post-Session Cycle (Psychology Agent)
 
 Ensures every session's decisions, findings, and reasoning propagate through the

--- a/.claude/skills/hunt/SKILL.md
+++ b/.claude/skills/hunt/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: hunt
+description: Systematic work discovery — scan TODO, architecture, cogarch, ideas, lessons for highest-value next work.
+user-invocable: true
+argument-hint: "[all | orthogonal | stale | quick | blocked | cogarch | ideas | extrapolate]"
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+---
+
 # Hunt — Systematic Work Discovery (Psychology Agent)
 
 Find the highest-value next work in the psychology agent project.

--- a/.claude/skills/knock/SKILL.md
+++ b/.claude/skills/knock/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: knock
+description: Single-option 10-order knock-on effect tracing for decisions and changes.
+user-invocable: true
+argument-hint: "[change to trace | inline | full]"
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+---
+
 # Knock — Single-Option Effect Tracing
 
 Trace the effects of ONE option, change, or decision through 10 orders of


### PR DESCRIPTION
## Summary

Three of four skills lacked YAML frontmatter with `user-invocable: true`, causing Claude Code to return "Unknown skill" when invoked via `/cycle`, `/hunt`, or `/knock`. Only `/doc` had the required frontmatter.

**Fixed:**
- `.claude/skills/cycle/SKILL.md` — added frontmatter
- `.claude/skills/hunt/SKILL.md` — added frontmatter (with argument-hint for all 8 scope options)
- `.claude/skills/knock/SKILL.md` — added frontmatter (with argument-hint for inline/full)

**Not affected:**
- `.claude/skills/doc/SKILL.md` — already had frontmatter
- `.claude/commands/adjudicate.md` — commands register by filename, no frontmatter needed
- `.claude/commands/capacity.md` — same

## How discovered

During claude-control cognitive architecture adaptation — created skills matching psychology-agent's pattern, hit the same "Unknown skill" error, traced to missing frontmatter.

## Test plan

- [ ] Restart Claude Code in psychology-agent project root
- [ ] Run `/cycle` — should load and execute the checklist
- [ ] Run `/hunt` — should load and scan for work
- [ ] Run `/knock` — should load and prompt for a change to trace

Generated with [Claude Code](https://claude.com/claude-code)