### PR TITLE
feat: unified /iterate loop + problem-solving discipline

### DIFF
--- a/.claude/skills/iterate/SKILL.md
+++ b/.claude/skills/iterate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: iterate
-description: Find next highest-value work and do it. Hunt → 2-order knock per candidate → discriminate → execute.
+description: Unified work loop — sync, hunt, discriminate, execute, cycle. One command does everything.
 user-invocable: true
 argument-hint: "[quick | deep | domain-filter]"
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Agent, AskUserQuestion, WebFetch
@@ -11,8 +11,9 @@ allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Agent, AskUserQuestion, WebF
 Find the single most important thing to do next, then do it.
 
 ```
+/sync      = check for inbound activity
 /hunt      = discover candidates, present to user
-/iterate   = discover → evaluate → discriminate → execute
+/iterate   = sync → hunt → discriminate → execute → cycle
 ```
 
 The user types `/iterate` and the next most important thing gets worked on.
@@ -33,6 +34,20 @@ Parse `$ARGUMENTS` to determine scope:
 ---
 
 ## Protocol
+
+### Phase 0: Sync (compressed)
+
+Run a quick sync internally — not user-facing output, just input to the hunt.
+
+1. `git fetch origin` — new remote commits?
+2. `git log HEAD..origin/main --oneline` — anything landed?
+3. `ls -t transport/sessions/*/from-*.json | head -5` — new inbound messages?
+4. `gh pr list --repo safety-quotient-lab/psychology-agent --json number,title` — open PRs?
+
+**If sync finds actionable items** (new commits, unread transport messages,
+open PRs), they become candidates in Phase 1 alongside hunt results.
+
+**If clean**, proceed silently to Phase 1.
 
 ### Phase 1: Hunt (compressed)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,9 @@ exceed available evidence, or any finding that a peer reviewer would challenge.
   invoked by /hunt and /adjudicate. Domain classify → ground → trace 10 orders.
 - `/sync` — Inter-agent mesh synchronization. Scans transport sessions for new
   messages, checks peer repos, writes ACKs, updates MANIFEST. No auto-merge.
-- `/iterate` — Autonomous work discovery + execution. Runs /hunt internally,
-  2-order knock per candidate, 4-mode discriminator (consensus → pragmatism →
-  parsimony → bare), then executes the winner and auto-cycles. May use WebFetch
-  during execution for research tasks.
+- `/iterate` — Unified work loop: sync → hunt → discriminate → execute → cycle.
+  One command does everything. Runs /sync as Phase 0, /hunt as Phase 1, 2-order
+  knock + 4-mode discriminator, executes the winner, auto-cycles at close.
 
 ## Commands (load on demand)
 
@@ -187,6 +186,33 @@ benefit everyone — they are not accommodations for edge cases.
 - **Modular structure** — each section should stand alone; don't require the user to
   hold prior sections in working memory to parse the current one
 - **Offer stopping points** — for long outputs, offer to pause rather than dumping
+
+---
+
+## Problem-Solving Discipline
+
+Before implementing a fix or new approach, write a 2-sentence plan explaining WHY
+the approach should work. If an approach fails twice, stop and list 3 alternative
+approaches before trying again. Do not brute-force system-level tasks through
+dozens of failing attempts.
+
+---
+
+## Workflow Continuity
+
+When resuming after a stall, context loss, or session continuation, reload relevant
+state from disk before continuing:
+- Re-read TODO.md, lab-notebook.md Current State, MEMORY.md Active Thread
+- Re-read any in-progress file that was being edited
+- Check `git status` and `git log -3` to reorient
+
+---
+
+## Environment Pitfalls
+
+- **Shell state does not persist between Bash calls** — environment variables, `cd`,
+  and shell functions set in one Bash tool call do not carry to the next. Either chain
+  commands in a single call (`export FOO=bar && use $FOO`) or write to a file and source it.
 
 ---
 


### PR DESCRIPTION
## Summary

- `/iterate` now runs `/sync` as Phase 0 before hunting — unified work loop: sync → hunt → discriminate → execute → cycle
- Added **Problem-Solving Discipline** to CLAUDE.md: 2-sentence plan before implementing, 3 alternatives after 2 failures
- Added **Workflow Continuity** to CLAUDE.md: reload state from disk on resume/stall
- Added **Environment Pitfalls** to CLAUDE.md: shell state doesn't persist between Bash tool calls

## Test plan

- [ ] Run `/iterate` and verify Phase 0 sync executes before hunt
- [ ] Verify `/iterate quick` still skips slow sources
- [ ] Confirm CLAUDE.md loads cleanly with new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cross-pollinated from claude-control insights analysis (session 2026-03-07/08).