### PR TITLE
cogarch: cross-project upgrades from claude-control

### DIFF
--- a/.claude/hooks/pushback-accumulator.sh
+++ b/.claude/hooks/pushback-accumulator.sh
@@ -25,6 +25,13 @@ if echo "$PROMPT" | grep -qiE "$PUSHBACK_PATTERNS"; then
 
   if [ "$COUNT" -ge 3 ]; then
     echo "[PUSHBACK] Structural disagreement pattern detected (${COUNT} pushback signals this session). T6: verify position stability — has the position shifted without new evidence?"
+    # Bridge to T10 lesson pipeline: generate a lesson candidate stub
+    # when structural disagreement threshold reached for the first time
+    if [ "$COUNT" -eq 3 ]; then
+      TOPIC_FILE="${HOME}/.claude/.pushback-topic.tmp"
+      TOPIC_SNIPPET=$(echo "$PROMPT" | head -c 120 | tr '\n' ' ')
+      echo "[PUSHBACK→T10] Structural disagreement reached threshold. Consider writing a lessons.md entry with pattern_type: structural-disagreement, domain: (classify from context), topic hint: \"${TOPIC_SNIPPET}\""
+    fi
   fi
 fi
 

--- a/.claude/rules/transport.md
+++ b/.claude/rules/transport.md
@@ -40,6 +40,28 @@ Every message should include `action_gate` with:
 Transport messages carry `epistemic_flags` as an array of strings.
 Flag scope limitations, unverified claims, and confidence boundaries.
 
+## Data Integrity (read-diff-write-verify)
+
+Before creating or modifying transport session files, follow this pattern
+(enforced by T16 Check 5):
+
+1. **Read** — list existing files in the target session directory and read
+   MANIFEST.json for current state
+2. **Diff** — compare existing messages against the intended write:
+   - Check for duplicate turn numbers (collision)
+   - Check for duplicate content (repeated ACK, re-sent message)
+   - Verify the new turn number follows the last existing turn
+3. **Write** — create the session file only if the diff shows it as needed.
+   Skip if a duplicate already exists
+4. **Verify** — after writing, confirm:
+   - File count in the session directory matches expected total
+   - MANIFEST.json updated with the new message reference
+   - No naming collisions introduced
+   - Turn sequence remains monotonic
+
+This prevents duplicate messages, naming collisions, and MANIFEST drift that
+compound across multi-session exchanges.
+
 ## Agent Card (.well-known/)
 
 In-repo agent-card describes git-PR transport topology.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,25 @@ These load automatically when editing matching files. CLAUDE.md retains universa
 
 ---
 
+## Anti-Patterns (known-failing approaches)
+
+- **Security tool source code triggers its own detection** — reading a scanner's
+  test fixtures fires the scanner's PostToolUse hook. Check whether the file contains
+  test injection strings before reading active scanner source.
+- **`settingSources: ['project']` in serverless** — silently no-ops in CF Workers
+  (no local filesystem). Inline identity and cogarch into the system prompt constant.
+- **Script architecture diverges from saved checkpoint** — inference/calibration scripts
+  that rebuild model classes differently from the training script produce silent failures
+  or cryptic KeyErrors. Canonical source for model architecture: the training script.
+- **Shell state across Bash calls** — env vars, `cd`, and shell functions do not persist.
+  Chain commands in a single call (`export FOO=bar && use $FOO`) or write to a file
+  and source it.
+- **Parry scanning its own source** — reading `/tmp/parry-install/` or similar paths
+  triggers taint from test fixture strings. Use `--ignore-path` or avoid reading
+  scanner internals in sessions with active Parry hooks.
+
+---
+
 ## Code Style
 
 **Semantic naming (all user-facing identifiers):** Every variable, parameter,

--- a/docs/cognitive-triggers.md
+++ b/docs/cognitive-triggers.md
@@ -528,11 +528,27 @@ creation, `gh api` write operations, transport message delivery to peer repos
    for the recipient or an open item on our backlog? GitHub issues can be
    closed but not deleted; PR comments persist; transport messages become
    part of peer committed state. Record obligations in MANIFEST
-3. **External interpretant** — who reads this on the external platform?
+3. **Reversibility classification** — classify before executing:
+   - **Reversible**: create branch, open draft PR, add label, create transport
+     message file → proceed
+   - **Hard to reverse**: merge PR, close issue, publish release, push transport
+     ACK (becomes part of peer committed state) → confirm with user
+   - **Irreversible**: delete repo, force push main, deploy to production,
+     remove published content → require explicit user approval
+4. **External interpretant** — who reads this on the external platform?
    Peer agents, their human operators, and public GitHub visitors may all
    see the action. Calibrate tone, detail, and epistemic flags for the
    external audience (inherits T4 Check 9 interpretant communities,
    applied to external platforms)
+5. **Data integrity (read-diff-write-verify)** — before writing to external
+   state (transport sessions, GitHub, APIs):
+   - **Read** — fetch existing state (list transport session files, check
+     open PRs/issues, read MANIFEST)
+   - **Diff** — compare existing against intended write. Identify duplicates,
+     naming collisions, superseded messages
+   - **Write** — create/modify only what the diff shows as needed. Skip duplicates
+   - **Verify** — after writing, confirm: file count matches expectation,
+     MANIFEST updated, no duplicates introduced, no records lost
 
 **Action**: If any check fails, pause and surface to user before proceeding.
 

--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -79,6 +79,10 @@ canonical sources where each constraint receives its mechanical enforcement.
 | P-14 | Trigger firing condition specificity required — principles without mechanical triggers remain aspirations | cognitive-triggers.md intro |
 | P-15 | Knock-on structural checkpoint mandatory at all scales — orders 7-10 scanned even for XS/S decisions | T14; MEMORY.md §Knock-on depth |
 | P-16 | Interpretant identification before writing — all relevant audiences identified; conflicts route to separate artifacts | T4 Check 9 |
+| P-17 | Reversibility classification before external actions — reversible/hard-to-reverse/irreversible; hard-to-reverse requires confirmation, irreversible requires explicit approval | T16 Check 3 |
+| P-18 | Data integrity read-diff-write-verify for transport and external writes — prevents duplicates, naming collisions, MANIFEST drift | T16 Check 5; transport.md §Data Integrity |
+| P-19 | Pushback accumulator bridges to lesson pipeline — 3+ pushbacks generates T10 lesson candidate with pattern_type: structural-disagreement | pushback-accumulator.sh hook; T10 |
+| P-20 | Anti-patterns registry in CLAUDE.md — known-failing approaches loaded every session, no graduation ceremony required | CLAUDE.md §Anti-Patterns |
 
 ---
 
@@ -132,7 +136,7 @@ protocol spec). A constraint without enforcement is an aspiration.
 **Retiring constraints:** Do not delete — mark as `[RETIRED: reason, date]`.
 Retired constraints preserve the reasoning for why they once existed.
 
-**Constraint count:** E:10, M:10, P:16, I:15, D:8 — 59 total
+**Constraint count:** E:10, M:10, P:20, I:15, D:8 — 63 total
 
 ---
 


### PR DESCRIPTION
## Summary

- **Anti-patterns registry** in CLAUDE.md — 5 known-failing approaches (scanner self-detection, serverless settingSources no-op, checkpoint architecture mismatch, shell state persistence, Parry source taint) loaded every session without graduation ceremony
- **T16 reversibility classification** — new Check 3 gates external actions as reversible (create branch, draft PR) / hard-to-reverse (merge PR, push ACK) / irreversible (delete repo, force push main)
- **T16 data integrity** — new Check 5 enforces read-diff-write-verify for transport writes and external state mutations, preventing duplicate messages, naming collisions, and MANIFEST drift
- **Transport rules** — §Data Integrity section with turn sequence and naming collision verification protocol
- **Pushback → lesson bridge** — pushback-accumulator.sh now emits a T10 lesson candidate hint at the 3-pushback structural disagreement threshold, closing the loop between disagreement detection and the lesson pipeline

Constraints P-17 through P-20 registered (59 → 63 total).

## Provenance

Cross-project evaluation of claude-control cogarch (12 triggers, 5 hooks) against psychology-agent cogarch (16 triggers, 12 hooks). Identified 9 upgrade candidates, implemented the 5 highest-value items, knocked the remaining 4.

## Test plan

- [ ] Verify anti-patterns section loads in new sessions (visible in T1 baseline output)
- [ ] Verify T16 Check 3 fires on next `gh pr create` or transport write
- [ ] Verify pushback accumulator emits T10 hint after 3+ pushbacks (test with deliberate disagreement)
- [ ] Verify constraints.md count matches (63 total)
- [ ] Verify transport.md §Data Integrity renders correctly in glob-scoped rule context

🤖 Generated with [Claude Code](https://claude.com/claude-code)