### PR TITLE
cogarch: hook health, lesson velocity, scan-peer diff verification

### DIFF
--- a/.claude/skills/scan-peer/SKILL.md
+++ b/.claude/skills/scan-peer/SKILL.md
@@ -44,6 +44,29 @@ Filter to content files only: `.mdx`, `.md`, `.astro` (pages with prose), `.ts` 
 
 If no content files changed, write a "no-findings" message and stop.
 
+### Phase 1b: Diff Verification (false-positive guard)
+
+Before passing changed files to Phase 2, filter out non-changes:
+
+1. **Skip empty-file diffs** — if both sides of the diff exist but contain
+   identical content (rename-only, mode change), exclude the file
+2. **Ignore whitespace-only diffs** — run `git diff --ignore-all-space` on each
+   file. If the whitespace-insensitive diff produces no output, exclude the file.
+   **Exception:** YAML frontmatter (between `---` delimiters) and Markdown table
+   rows (lines matching `^\|`) treat whitespace as significant — keep these files
+3. **Verify both sides exist** — if `git diff` reports a file as "added" but
+   the file existed in the prior commit (rename detection), verify the content
+   actually changed. A diff against a non-existent file reports the entire file
+   as new content, which inflates findings
+4. **Log filtered files** — record `files_filtered` count and reasons in the
+   transport payload `scan_range` block for audit trail
+
+Add to `scan_range` in Phase 4 payload:
+```json
+"files_filtered": N,
+"filter_reasons": { "empty_diff": 0, "whitespace_only": 0, "existence_check": 0 }
+```
+
 ### Phase 2: Scan Each Changed File
 
 For each changed file, evaluate across these dimensions:

--- a/docs/cognitive-triggers.md
+++ b/docs/cognitive-triggers.md
@@ -364,17 +364,22 @@ they want to grok or internalize something, or (c) a genuine conceptual shift oc
 
 **Checks**:
 1. Does this lesson already exist in lessons.md? If so, increment `recurrence`
+   and update `last_seen` to today's date (`date -Idate`)
 2. Format per lessons.md.example — YAML frontmatter + narrative fields
 3. Use full timestamp: `date '+%Y-%m-%dT%H:%M %Z'`
-4. Classify: `pattern_type`, `domain`, `severity` from the schema enums
+4. Classify: `pattern_type`, `domain`, `severity` from the schema enums.
+   Set `first_seen` to today's date on creation; set `last_seen` = `first_seen`
 5. If 3+ lessons share the same `pattern_type` or `domain`, flag `[→ PROMOTE]`
-6. **Graduation path** — for any entry already flagged `[→ PROMOTE]`: determine
-   whether the pattern has stabilized across 2+ sessions. If yes: draft a concrete
-   CLAUDE.md convention candidate (plain imperative sentence, no jargon) and surface
-   it to the user for review. User sets `promotion_status: approved` to authorize.
-   Graduation ceremony (/cycle Step 8b) then executes: (1) append to CLAUDE.md,
-   (2) update lessons.md `promotion_status: graduated` + `graduated_to` + date,
-   (3) log in lab-notebook. Remove `[→ PROMOTE]` flag once graduated.
+6. **Velocity-gated promotion** — for any entry already flagged `[→ PROMOTE]`:
+   check `recurrence >= 2 AND (last_seen - first_seen) <= 10 calendar days`.
+   Fast-recurring patterns get promoted; slow-burn patterns (same recurrence
+   spread over months) hold for more evidence. If velocity gate passes: draft
+   a concrete CLAUDE.md convention candidate (plain imperative sentence, no
+   jargon) and surface it to the user for review. User sets
+   `promotion_status: approved` to authorize. Graduation ceremony (/cycle
+   Step 8b) then executes: (1) append to CLAUDE.md, (2) update lessons.md
+   `promotion_status: graduated` + `graduated_to` + date, (3) log in
+   lab-notebook. Remove `[→ PROMOTE]` flag once graduated.
 
 **Action**: Write entry to lessons.md. lessons.md is gitignored; lessons.md.example
 is the tracked format stub with schema definition.
@@ -390,7 +395,11 @@ is the tracked format stub with schema definition.
 2. Audit MEMORY.md against current project state
 3. Audit CLAUDE.md against current project state
 4. Check for inconsistencies between docs
-5. For deferred items: document future mitigations
+5. **Hook health** — parse `.claude/settings.json`, resolve each hook command
+   path, verify the script file exists and has execute permission. Report any
+   missing or non-executable hooks. (Firing verification deferred — most hooks
+   produce ephemeral stdout with no persistent artifact to check.)
+6. For deferred items: document future mitigations
 
 **Action**: Report findings. Fix what can be fixed immediately. Document deferrals
 with mitigations.

--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -83,6 +83,9 @@ canonical sources where each constraint receives its mechanical enforcement.
 | P-18 | Data integrity read-diff-write-verify for transport and external writes — prevents duplicates, naming collisions, MANIFEST drift | T16 Check 5; transport.md §Data Integrity |
 | P-19 | Pushback accumulator bridges to lesson pipeline — 3+ pushbacks generates T10 lesson candidate with pattern_type: structural-disagreement | pushback-accumulator.sh hook; T10 |
 | P-20 | Anti-patterns registry in CLAUDE.md — known-failing approaches loaded every session, no graduation ceremony required | CLAUDE.md §Anti-Patterns |
+| P-21 | Hook health audit in T11 — verify each hook script exists and has execute permission | T11 Check 5 |
+| P-22 | Lesson promotion velocity gate — recurrence >= 2 AND span <= 10 calendar days required for promotion | T10 Check 6 |
+| P-23 | Diff verification in /scan-peer — skip empty diffs, whitespace-only changes, verify file existence before reporting | /scan-peer Phase 1b |
 
 ---
 
@@ -136,7 +139,7 @@ protocol spec). A constraint without enforcement is an aspiration.
 **Retiring constraints:** Do not delete — mark as `[RETIRED: reason, date]`.
 Retired constraints preserve the reasoning for why they once existed.
 
-**Constraint count:** E:10, M:10, P:20, I:15, D:8 — 63 total
+**Constraint count:** E:10, M:10, P:23, I:15, D:8 — 66 total
 
 ---
 

--- a/lessons.md.example
+++ b/lessons.md.example
@@ -22,10 +22,12 @@ full lifecycle spec.
 ## YYYY-MM-DDTHH:MM TZ — [Lesson Title]
 
 ```yaml
-pattern_type: [reasoning-error | process-failure | architecture-insight | communication-gap | tooling-discovery]
+pattern_type: [reasoning-error | process-failure | architecture-insight | communication-gap | tooling-discovery | structural-disagreement]
 domain: [cogarch | memory | sub-agent | evaluation | documentation | security | workflow]
 severity: [low | medium | high]
 recurrence: 1           # increment on each re-encounter
+first_seen: null         # ISO date of first occurrence (set on creation)
+last_seen: null          # ISO date of most recent recurrence (updated on each increment)
 trigger_relevant: null   # T-number if this maps to a trigger improvement, else null
 promotion_status: null   # null | candidate | promoted | retired
 ```


### PR DESCRIPTION
## Summary

Follow-up to PR #72. Three additional upgrades from knock analysis:

- **T11 hook health check** — new Check 5 verifies each hook script exists and has execute permission during architecture audits (P-21)
- **T10 velocity-gated promotion** — `first_seen`/`last_seen` fields in lesson schema, promotion requires `recurrence >= 2` within 10 calendar days. Also adds `structural-disagreement` to pattern_type enum (P-22)
- **/scan-peer Phase 1b diff verification** — filters empty diffs, whitespace-only changes, verifies file existence before scanning. Adds `files_filtered` and `filter_reasons` to transport payload (P-23)

Constraints P-21 through P-23 registered (63 → 66 total).

## Test plan

- [ ] Verify T11 hook health check reports correctly when run on demand
- [ ] Verify lesson velocity fields appear in lessons.md.example schema
- [ ] Verify /scan-peer Phase 1b filters whitespace-only diffs in next scan run
- [ ] Verify constraints.md count matches (66 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)